### PR TITLE
1.修复推荐歌单详情因commit 1b1140f导致的track.publishTime字段无法读取的问题

### DIFF
--- a/src/renderer/components/TrackListItem.vue
+++ b/src/renderer/components/TrackListItem.vue
@@ -55,7 +55,7 @@
 
       <div v-if="showTrackTime" class="createTime">
         {{
-          track.createTime ? getPublishTime(track.createTime) : getPublishTime(track.album.publishTime)
+          track.createTime ? getPublishTime(track.createTime) : getPublishTime(track.album?.publishTime ?? track.publishTime)
         }}
       </div>
       <div v-if="showLikeButton" class="actions">


### PR DESCRIPTION
1.修复推荐歌单详情因commit 1b1140f导致的track.publishTime字段无法读取，目前为适配两种情况,判断track.album.publishTime和tracker.publishTime。

推荐歌单无法访问：
<img width="1080" alt="image" src="https://github.com/user-attachments/assets/3e4ee197-3fb6-4f38-9119-bfff0bf17a1b" />
shell里报错:
<img width="579" alt="image" src="https://github.com/user-attachments/assets/5c29a6e9-bd5b-48e2-8b43-d66d8a1a55b1" />
接口返回参数,在item里面直接存在publishtime
<img width="560" alt="image" src="https://github.com/user-attachments/assets/06337477-218c-409e-a01a-04245708d494" />
