### PR TITLE
修复：解决Linux设备上MPRIS启动时的竞态条件问题

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -699,7 +699,7 @@ class BackGround {
       this.tray = createTray(this.win)
       if (Constants.IS_LINUX) {
         const createMpris = await import('./mpris').then((m) => m.createMpris)
-        this.mpris = createMpris(this.win)
+        this.mpris = await createMpris(this.win)
       }
 
       if (store.get('settings.enableGlobalShortcut') || false) {

--- a/src/main/mpris.ts
+++ b/src/main/mpris.ts
@@ -101,6 +101,14 @@ class Mpris implements MprisImpl {
   }
 }
 
-export function createMpris(win: BrowserWindow) {
-  return new Mpris(win)
+// 使用 async 关键字，让这个函数本身变成异步的
+export async function createMpris(win: BrowserWindow): Promise<MprisImpl> {
+  // 创建实例的过程不变
+  const mprisInstance = new Mpris(win)
+
+  // 使用 setImmediate 来“暂停”一瞬间，这会把后续操作推迟到下一个事件循环
+  // 这既打破了启动时的竞态条件，又能安全地返回完整的类实例
+  await new Promise((resolve) => setImmediate(resolve))
+
+  return mprisInstance
 }


### PR DESCRIPTION
`## 问题描述`

`在 Linux 系统（如 Steam Deck）上，应用在冷启动时有很高的概率会因为竞态条件而崩溃。`
`这是因为 MPRIS D-Bus 服务尚未完全初始化，但主进程的 IPC 处理器已经开始尝试使用它，导致传入了一个 `null` 值，从而触发了 `TypeError: ... conversion failure from null` 的致命错误。`

`## 解决方案`

`本次修复通过将 `mpris.ts` 中的 `createMpris` 函数修改为异步函数 (async function) 来解决此问题。`
`在 `index.ts` 中调用此函数时，使用了 `await` 关键字来等待 `mpris` 服务完全初始化，然后再将其传递给 IPCs 模块。`
`这确保了在任何情况下，IPC 处理器使用的都是一个有效的、已准备就绪的 `mpris` 实例，从而彻底解决了该竞态条件。`

`## 测试环境`

* `设备: Steam Deck`
* `操作系统: SteamOS (基于 Arch Linux)`
* `容器方案: Distrobox + Ubuntu`

`## 测试结果`

`应用此修复后，启动崩溃的问题得到解决，应用能够稳定启动。`

---