### PR TITLE
修复播放界面展开时背景动画错位的问题

### DIFF
--- a/src/renderer/components/CommonPlayer.vue
+++ b/src/renderer/components/CommonPlayer.vue
@@ -457,7 +457,7 @@ onMounted(() => {
 }
 
 .lyrics-container {
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   right: 0;

--- a/src/renderer/components/CreativePlayer.vue
+++ b/src/renderer/components/CreativePlayer.vue
@@ -575,7 +575,7 @@ onBeforeUnmount(() => {
 }
 
 .lt-background {
-  position: fixed;
+  position: absolute;
   top: 0;
   left: 0;
   bottom: 0;
@@ -602,7 +602,7 @@ onBeforeUnmount(() => {
 }
 
 .title-name {
-  position: fixed;
+  position: absolute;
   top: 28px;
   left: 15vw;
   font-weight: bold;


### PR DESCRIPTION
播放界面向上展开时背景会错位出现，伴随奇怪的动画

修复前：

![PixPin_2025-07-02_20-05-52](https://github.com/user-attachments/assets/e419d56d-dcb6-4019-8b01-eec30047fd2b)

---

修复后：
![PixPin_2025-07-02_20-06-42](https://github.com/user-attachments/assets/6c539e9f-1e11-4d0b-b701-8123027955ce)


