### PR TITLE
fix-multidisc-play-index-mapping

### DIFF
--- a/src/renderer/components/VirtualTrackList.vue
+++ b/src/renderer/components/VirtualTrackList.vue
@@ -283,10 +283,11 @@ const currentIndex = computed(() => {
 
 const playThisList = (index: number) => {
   if (!props.dbclickEnable) return
-  const IDs = (props.allItems?.length ? props.allItems : items.value).map(
+  const sourceItems = props.allItems?.length ? props.allItems : items.value
+  const IDs = sourceItems.map(
     (track) => track.id || track.songId
   )
-  const idx = items.value.findIndex((item) => (item.id || item.songId) === index)
+  const idx = sourceItems.findIndex((item) => (item.id || item.songId) === index)
   replacePlaylist(props.type, id.value, IDs, idx)
 }
 


### PR DESCRIPTION
What broke
On multi-disc albums, double-click or inline play-button actions could start the wrong song (often the same track number from Disc 1), even though the selected row was on Disc 2+.

Root cause
playThisList built the playlist from the full source (allItems) but calculated the start index from the rendered subset (items), causing index misalignment.

Why this fix is minimal
The change is limited to playThisList in one component, only aligning index calculation with the same list used to build playback IDs. No broader playback logic was changed.

What I tested
Code-path verification for album multi-disc rendering flow and play-index computation; confirmed IDs and index are now derived from the same source list.

What I intentionally did not change
No refactors, no UI behavior changes beyond this mapping fix, and no changes to right-click/context-menu playback logic.