### PR TITLE
修复：桌面歌词阴影颜色配置不生效

### DIFF
--- a/src/renderer/components/OsdLyricContainer.vue
+++ b/src/renderer/components/OsdLyricContainer.vue
@@ -52,7 +52,8 @@ const {
   playedLrcColor,
   unplayLrcColor,
   mode,
-  font
+  font,
+  textShadow
 } = storeToRefs(osdLyricStore)
 
 const lyricRefs = ref<InstanceType<typeof LyricLine>[]>([])
@@ -414,6 +415,8 @@ onBeforeUnmount(() => {
       background-size: 200% 100%;
       background-position: 100% 0%;
 
+      text-shadow: 0 0 2px v-bind('textShadow');
+
       overflow-wrap: break-word;
       -webkit-text-stroke: 0.05px rgba(46, 46, 46, 0.3);
     }
@@ -431,6 +434,9 @@ onBeforeUnmount(() => {
       color: transparent;
       background-size: 200% 100%;
       background-position: 100% 0%;
+
+      text-shadow: 0 0 2px v-bind('textShadow');
+
       overflow-wrap: break-word;
       -webkit-text-stroke: 0.05px rgba(46, 46, 46, 0.3);
     }


### PR DESCRIPTION
### 问题描述

桌面歌词“阴影颜色”配置项实际无法生效。配置项具体位置如图：

<img width="1688" height="1075" alt="image" src="https://github.com/user-attachments/assets/742d387c-e47b-4c8c-babe-de342a9c1b20" />

### 根因分析

桌面歌词“阴影颜色”配置项 `textShadow` 在 `osdLyric.ts -> useOsdLyricStore` 方法中导出但未被使用。
（如果是因为显示效果不佳而有意为之，可能需要考虑优化对应UI控件的显示逻辑）

### 修改方案

在桌面歌词 `OsdLyricContainer.vue` 的两种 class 中添加样式 `text-shadow: 0 0 2px v-bind('textShadow');`.
其中阴影 `offset-x | offset-y | blur-radius` 部分暂未支持配置，如有需要再进行修改。

### 验证效果

仅在Windows11下测试，未测试其他平台生效情况。

- 修正后的默认样式（白、黑背景对比）：
   <img width="880" height="132" alt="image" src="https://github.com/user-attachments/assets/3dfc0a8a-3263-454a-8cb6-ea13887d83f0" />
   <img width="880" height="132" alt="image" src="https://github.com/user-attachments/assets/cd935d76-a71a-407b-a4b6-be21d5a0b9ef" />

- 修正前：
   <img width="880" height="132" alt="image" src="https://github.com/user-attachments/assets/b7cbd599-411f-4274-aa9b-19243e753831" />
   <img width="880" height="132" alt="image" src="https://github.com/user-attachments/assets/112c136a-c6bc-4393-bac0-6d7e6189e963" />

烦请活跃维护者评审。
