### PR TITLE
feat: 歌词高亮颜色 & API 背景图片缓存

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,24 +4,19 @@ about: Create a report to help us improve
 title: ''
 labels: bug
 assignees: stark81
-
 ---
 
-**问题描述（Describe the bug）**
-清晰简明地描述遇到的问题（A clear and concise description of what the bug is.）
+**问题描述（Describe the bug）** 清晰简明地描述遇到的问题（A clear and concise description of what the bug is.）
 
-**重现步骤（To Reproduce）**
-问题复现步骤:（Steps to reproduce the behavior:）
+**重现步骤（To Reproduce）** 问题复现步骤:（Steps to reproduce the behavior:）
 
-**预期行为（Expected behavior）**
-明确说明你期望发生的正常情况。（A clear and concise description of what you expected to happen.）
+**预期行为（Expected behavior）** 明确说明你期望发生的正常情况。（A clear and concise description of what you expected to happen.）
 
 **设备信息 -- 请完善下面的信息：（Device information -- please complete the following information:）**
- - 操作系统名称: [例: Windows, macOS, Linux...] （OS Name: [e.g. Windows, macOS, Linux...]）
- - 操作系统版本: [例: 11, 10.14...] （OS Version: [e.g. 11, 10.14...]）
 
-**截图与附件（Screenshots & Attachments）**
-如果可以的话，请添加截图或文件附件帮助说明问题。（If applicable, add screenshots to help explain your problem.）
+- 操作系统名称: [例: Windows, macOS, Linux...] （OS Name: [e.g. Windows, macOS, Linux...]）
+- 操作系统版本: [例: 11, 10.14...] （OS Version: [e.g. 11, 10.14...]）
 
-**其他补充（Additional context）**
-在此添加关于该问题的其他补充说明。（Add any other context about the problem here.）
+**截图与附件（Screenshots & Attachments）** 如果可以的话，请添加截图或文件附件帮助说明问题。（If applicable, add screenshots to help explain your problem.）
+
+**其他补充（Additional context）** 在此添加关于该问题的其他补充说明。（Add any other context about the problem here.）

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,13 @@
 version: 2
 updates:
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
-      interval: "monthly"
+      interval: 'monthly'
     target-branch: 'dev.feature.depend-pull'
     assignees:
-      - "stark81"
+      - 'stark81'
     reviewers:
-      - "stark81"
+      - 'stark81'
     open-pull-requests-limit: 5
     versioning-strategy: increase

--- a/src/main/IPCs.ts
+++ b/src/main/IPCs.ts
@@ -12,6 +12,7 @@ import { CacheAPIs } from './utils/CacheApis'
 import { deleteExcessCache, createWorker, getTrackDetail } from './utils'
 import cache from './cache'
 import { registerGlobalShortcuts } from './globalShortcut'
+import apiBgCache from './apiBgCache'
 import { createMenu } from './menu'
 import log from './log'
 import navidrome from './streaming/navidrome'
@@ -791,6 +792,33 @@ async function initOtherIpcMain(win: BrowserWindow): Promise<void> {
 
   ipcMain.handle('get-cache-path', () => {
     return path.join(app.getPath('userData'), 'audioCache')
+  })
+
+  ipcMain.handle('apiBgCache-getRandom', async () => {
+    let cachedPath = apiBgCache.getRandomCachedPath()
+    if (!cachedPath) {
+      cachedPath = await apiBgCache.downloadOne()
+    }
+    if (cachedPath) {
+      return `atom://local-resource/${encodeURIComponent(cachedPath)}`
+    }
+    return null
+  })
+
+  ipcMain.handle('apiBgCache-getOne', async () => {
+    const cachedPath = await apiBgCache.downloadOne()
+    if (cachedPath) {
+      return `atom://local-resource/${encodeURIComponent(cachedPath)}`
+    }
+    return null
+  })
+
+  ipcMain.handle('apiBgCache-fill', async (_event, maxCount: number) => {
+    await apiBgCache.fillTo(maxCount)
+  })
+
+  ipcMain.handle('apiBgCache-setCount', async (_event, maxCount: number) => {
+    apiBgCache.evictToMax(maxCount)
   })
 }
 

--- a/src/main/IPCs.ts
+++ b/src/main/IPCs.ts
@@ -820,6 +820,18 @@ async function initOtherIpcMain(win: BrowserWindow): Promise<void> {
   ipcMain.handle('apiBgCache-setCount', async (_event, maxCount: number) => {
     apiBgCache.evictToMax(maxCount)
   })
+
+  ipcMain.handle('save-api-bg', async (_event, filePath: string) => {
+    if (!filePath || !fs.existsSync(filePath)) return null
+    const { dialog } = await import('electron')
+    const result = await dialog.showSaveDialog({
+      defaultPath: path.basename(filePath),
+      filters: [{ name: 'Images', extensions: ['jpg', 'jpeg', 'png', 'webp', 'gif'] }]
+    })
+    if (result.canceled || !result.filePath) return null
+    fs.copyFileSync(filePath, result.filePath)
+    return result.filePath
+  })
 }
 
 async function initMprisIpcMain(win: BrowserWindow, mpris: MprisImpl): Promise<void> {

--- a/src/main/IPCs.ts
+++ b/src/main/IPCs.ts
@@ -794,10 +794,10 @@ async function initOtherIpcMain(win: BrowserWindow): Promise<void> {
     return path.join(app.getPath('userData'), 'audioCache')
   })
 
-  ipcMain.handle('apiBgCache-getRandom', async () => {
+  ipcMain.handle('apiBgCache-getRandom', async (_event, apiUrl?: string) => {
     let cachedPath = apiBgCache.getRandomCachedPath()
     if (!cachedPath) {
-      cachedPath = await apiBgCache.downloadOne()
+      cachedPath = await apiBgCache.downloadOne(apiUrl)
     }
     if (cachedPath) {
       return `atom://local-resource/${encodeURIComponent(cachedPath)}`
@@ -805,16 +805,16 @@ async function initOtherIpcMain(win: BrowserWindow): Promise<void> {
     return null
   })
 
-  ipcMain.handle('apiBgCache-getOne', async () => {
-    const cachedPath = await apiBgCache.downloadOne()
+  ipcMain.handle('apiBgCache-getOne', async (_event, apiUrl?: string) => {
+    const cachedPath = await apiBgCache.downloadOne(apiUrl)
     if (cachedPath) {
       return `atom://local-resource/${encodeURIComponent(cachedPath)}`
     }
     return null
   })
 
-  ipcMain.handle('apiBgCache-fill', async (_event, maxCount: number) => {
-    await apiBgCache.fillTo(maxCount)
+  ipcMain.handle('apiBgCache-fill', async (_event, maxCount: number, apiUrl?: string) => {
+    await apiBgCache.fillTo(maxCount, apiUrl)
   })
 
   ipcMain.handle('apiBgCache-setCount', async (_event, maxCount: number) => {

--- a/src/main/apiBgCache.ts
+++ b/src/main/apiBgCache.ts
@@ -88,14 +88,13 @@ class ApiBgCache {
 
   async fillTo(maxCount: number): Promise<void> {
     const entries = this.getCacheIndex()
-    const needed = maxCount - entries.length
+    let needed = maxCount - entries.length
     if (needed <= 0) return
 
-    const downloads: Promise<string | null>[] = []
     for (let i = 0; i < needed; i++) {
-      downloads.push(this.downloadOne())
+      const result = await this.downloadOne()
+      if (!result) break
     }
-    await Promise.allSettled(downloads)
     this.evictToMax(maxCount)
   }
 

--- a/src/main/apiBgCache.ts
+++ b/src/main/apiBgCache.ts
@@ -32,7 +32,7 @@ class ApiBgCache {
   }
 
   private async serialized<T>(fn: () => T | Promise<T>): Promise<T> {
-    return this.lock = this.lock.then(fn)
+    return (this.lock = this.lock.then(fn))
   }
 
   getCacheDir(): string {

--- a/src/main/apiBgCache.ts
+++ b/src/main/apiBgCache.ts
@@ -59,9 +59,10 @@ class ApiBgCache {
     return path.join(this.cacheDir, entry.filename)
   }
 
-  async downloadOne(): Promise<string | null> {
+  async downloadOne(apiUrl?: string): Promise<string | null> {
     try {
-      const response = await fetch('https://acg.suyanw.cn/random.php', {
+      const url = apiUrl || 'https://acg.suyanw.cn/random.php'
+      const response = await fetch(url, {
         signal: AbortSignal.timeout(15000)
       })
       if (!response.ok) {
@@ -86,13 +87,13 @@ class ApiBgCache {
     }
   }
 
-  async fillTo(maxCount: number): Promise<void> {
+  async fillTo(maxCount: number, apiUrl?: string): Promise<void> {
     const entries = this.getCacheIndex()
     let needed = maxCount - entries.length
     if (needed <= 0) return
 
     for (let i = 0; i < needed; i++) {
-      const result = await this.downloadOne()
+      const result = await this.downloadOne(apiUrl)
       if (!result) break
     }
     this.evictToMax(maxCount)

--- a/src/main/apiBgCache.ts
+++ b/src/main/apiBgCache.ts
@@ -11,8 +11,14 @@ interface CacheEntry {
   addedAt: number
 }
 
+const extMap: Record<string, string> = {
+  jpeg: 'jpg',
+  'svg+xml': 'svg'
+}
+
 class ApiBgCache {
   private cacheDir: string
+  private lock: Promise<void> = Promise.resolve()
 
   constructor() {
     this.cacheDir = path.join(app.getPath('userData'), CACHE_DIR)
@@ -23,6 +29,10 @@ class ApiBgCache {
     if (!fs.existsSync(this.cacheDir)) {
       fs.mkdirSync(this.cacheDir, { recursive: true })
     }
+  }
+
+  private async serialized<T>(fn: () => T | Promise<T>): Promise<T> {
+    return this.lock = this.lock.then(fn)
   }
 
   getCacheDir(): string {
@@ -62,23 +72,24 @@ class ApiBgCache {
   async downloadOne(apiUrl?: string): Promise<string | null> {
     try {
       const url = apiUrl || 'https://acg.suyanw.cn/random.php'
-      const response = await fetch(url, {
-        signal: AbortSignal.timeout(15000)
-      })
+      const response = await fetch(url, { signal: AbortSignal.timeout(15000) })
       if (!response.ok) {
         log.error('API bg cache download failed:', response.status)
         return null
       }
       const buffer = Buffer.from(await response.arrayBuffer())
       const contentType = response.headers.get('content-type') || 'image/jpeg'
-      const ext = contentType.split('/').pop() || 'jpg'
+      const rawExt = contentType.split('/').pop() || 'jpg'
+      const ext = extMap[rawExt] || rawExt
       const filename = `bg_${Date.now()}_${Math.random().toString(36).slice(2, 8)}.${ext}`
       const filePath = path.join(this.cacheDir, filename)
       fs.writeFileSync(filePath, buffer)
 
-      const entries = this.getCacheIndex()
-      entries.push({ filename, addedAt: Date.now() })
-      this.saveCacheIndex(entries)
+      await this.serialized(() => {
+        const entries = this.getCacheIndex()
+        entries.push({ filename, addedAt: Date.now() })
+        this.saveCacheIndex(entries)
+      })
 
       return filePath
     } catch (error) {
@@ -90,12 +101,12 @@ class ApiBgCache {
   async fillTo(maxCount: number, apiUrl?: string): Promise<void> {
     const entries = this.getCacheIndex()
     let needed = maxCount - entries.length
-    if (needed <= 0) return
 
     for (let i = 0; i < needed; i++) {
       const result = await this.downloadOne(apiUrl)
       if (!result) break
     }
+
     this.evictToMax(maxCount)
   }
 
@@ -110,9 +121,11 @@ class ApiBgCache {
     for (const entry of toRemove) {
       const filePath = path.join(this.cacheDir, entry.filename)
       try {
-        if (fs.existsSync(filePath)) fs.unlinkSync(filePath)
-      } catch (e) {
-        log.error('Failed to remove cached bg file:', e)
+        fs.unlinkSync(filePath)
+      } catch (e: any) {
+        if (e?.code !== 'ENOENT') {
+          log.error('Failed to remove cached bg file:', e)
+        }
       }
     }
 
@@ -124,9 +137,11 @@ class ApiBgCache {
     for (const entry of entries) {
       const filePath = path.join(this.cacheDir, entry.filename)
       try {
-        if (fs.existsSync(filePath)) fs.unlinkSync(filePath)
-      } catch (e) {
-        log.error('Failed to clear cached bg file:', e)
+        fs.unlinkSync(filePath)
+      } catch (e: any) {
+        if (e?.code !== 'ENOENT') {
+          log.error('Failed to clear cached bg file:', e)
+        }
       }
     }
     this.saveCacheIndex([])

--- a/src/main/apiBgCache.ts
+++ b/src/main/apiBgCache.ts
@@ -1,0 +1,136 @@
+import path from 'path'
+import fs from 'fs'
+import { app } from 'electron'
+import log from './log'
+
+const CACHE_DIR = 'apiBgCache'
+const INDEX_FILE = 'index.json'
+
+interface CacheEntry {
+  filename: string
+  addedAt: number
+}
+
+class ApiBgCache {
+  private cacheDir: string
+
+  constructor() {
+    this.cacheDir = path.join(app.getPath('userData'), CACHE_DIR)
+    this.initCache()
+  }
+
+  private initCache() {
+    if (!fs.existsSync(this.cacheDir)) {
+      fs.mkdirSync(this.cacheDir, { recursive: true })
+    }
+  }
+
+  getCacheDir(): string {
+    return this.cacheDir
+  }
+
+  private getIndexPath(): string {
+    return path.join(this.cacheDir, INDEX_FILE)
+  }
+
+  private getCacheIndex(): CacheEntry[] {
+    const indexPath = this.getIndexPath()
+    if (!fs.existsSync(indexPath)) return []
+    try {
+      const content = fs.readFileSync(indexPath, 'utf-8')
+      return JSON.parse(content)
+    } catch {
+      return []
+    }
+  }
+
+  private saveCacheIndex(entries: CacheEntry[]) {
+    fs.writeFileSync(this.getIndexPath(), JSON.stringify(entries, null, 2))
+  }
+
+  getCacheCount(): number {
+    return this.getCacheIndex().length
+  }
+
+  getRandomCachedPath(): string | null {
+    const entries = this.getCacheIndex()
+    if (entries.length === 0) return null
+    const entry = entries[Math.floor(Math.random() * entries.length)]
+    return path.join(this.cacheDir, entry.filename)
+  }
+
+  async downloadOne(): Promise<string | null> {
+    try {
+      const response = await fetch('https://acg.suyanw.cn/random.php', {
+        signal: AbortSignal.timeout(15000)
+      })
+      if (!response.ok) {
+        log.error('API bg cache download failed:', response.status)
+        return null
+      }
+      const buffer = Buffer.from(await response.arrayBuffer())
+      const contentType = response.headers.get('content-type') || 'image/jpeg'
+      const ext = contentType.split('/').pop() || 'jpg'
+      const filename = `bg_${Date.now()}_${Math.random().toString(36).slice(2, 8)}.${ext}`
+      const filePath = path.join(this.cacheDir, filename)
+      fs.writeFileSync(filePath, buffer)
+
+      const entries = this.getCacheIndex()
+      entries.push({ filename, addedAt: Date.now() })
+      this.saveCacheIndex(entries)
+
+      return filePath
+    } catch (error) {
+      log.error('API bg cache download failed:', error)
+      return null
+    }
+  }
+
+  async fillTo(maxCount: number): Promise<void> {
+    const entries = this.getCacheIndex()
+    const needed = maxCount - entries.length
+    if (needed <= 0) return
+
+    const downloads: Promise<string | null>[] = []
+    for (let i = 0; i < needed; i++) {
+      downloads.push(this.downloadOne())
+    }
+    await Promise.allSettled(downloads)
+    this.evictToMax(maxCount)
+  }
+
+  evictToMax(maxCount: number) {
+    let entries = this.getCacheIndex()
+    if (entries.length <= maxCount) return
+
+    entries.sort((a, b) => a.addedAt - b.addedAt)
+    const toRemove = entries.slice(0, entries.length - maxCount)
+    entries = entries.slice(entries.length - maxCount)
+
+    for (const entry of toRemove) {
+      const filePath = path.join(this.cacheDir, entry.filename)
+      try {
+        if (fs.existsSync(filePath)) fs.unlinkSync(filePath)
+      } catch (e) {
+        log.error('Failed to remove cached bg file:', e)
+      }
+    }
+
+    this.saveCacheIndex(entries)
+  }
+
+  clearAll() {
+    const entries = this.getCacheIndex()
+    for (const entry of entries) {
+      const filePath = path.join(this.cacheDir, entry.filename)
+      try {
+        if (fs.existsSync(filePath)) fs.unlinkSync(filePath)
+      } catch (e) {
+        log.error('Failed to clear cached bg file:', e)
+      }
+    }
+    this.saveCacheIndex([])
+  }
+}
+
+export default new ApiBgCache()

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -70,7 +70,8 @@ const mainAvailChannels: string[] = [
   'apiBgCache-getRandom',
   'apiBgCache-getOne',
   'apiBgCache-fill',
-  'apiBgCache-setCount'
+  'apiBgCache-setCount',
+  'save-api-bg'
 ]
 const rendererAvailChannels: string[] = [
   'msgHandleScanLocalMusic',

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -66,7 +66,11 @@ const mainAvailChannels: string[] = [
   'track-scrobble',
   'get-screenshot',
   'delete-screenshot',
-  'get-cache-path'
+  'get-cache-path',
+  'apiBgCache-getRandom',
+  'apiBgCache-getOne',
+  'apiBgCache-fill',
+  'apiBgCache-setCount'
 ]
 const rendererAvailChannels: string[] = [
   'msgHandleScanLocalMusic',

--- a/src/renderer/components/BackgroundPage.vue
+++ b/src/renderer/components/BackgroundPage.vue
@@ -44,6 +44,7 @@ import { usePlayerStore } from '../store/player'
 import { storeToRefs } from 'pinia'
 import { Vibrant } from 'node-vibrant/browser'
 import Color from 'color'
+import { currentApiBgPath } from '../store/currentBg'
 
 const playerThemeStore = usePlayerThemeStore()
 const { activeBG } = storeToRefs(playerThemeStore)
@@ -197,10 +198,12 @@ const loadApiBgFromCache = async (replenish = true) => {
   const fresh = await window.mainApi?.invoke('apiBgCache-getOne', apiUrl)
   if (fresh) {
     tempSrc.value = `url(${fresh})`
+    currentApiBgPath.value = decodeURIComponent(fresh.replace('atom://local-resource/', ''))
   } else {
     const cached = await window.mainApi?.invoke('apiBgCache-getRandom', apiUrl)
     if (cached) {
       tempSrc.value = `url(${cached})`
+      currentApiBgPath.value = decodeURIComponent(cached.replace('atom://local-resource/', ''))
     }
   }
   if (replenish) {

--- a/src/renderer/components/BackgroundPage.vue
+++ b/src/renderer/components/BackgroundPage.vue
@@ -178,7 +178,7 @@ watch(
   () => {
     stopApiRefreshTimer()
     if (activeBG.value.type === 'api' && activeBG.value.switchMode === 'track') {
-      tempSrc.value = `url(${activeBG.value.src}${activeBG.value.src.includes('?') ? '&' : '?'}t=${Date.now()})`
+      loadApiBgFromCache()
     }
   }
 )
@@ -190,12 +190,28 @@ const stopApiRefreshTimer = () => {
   }
 }
 
+const loadApiBgFromCache = async (replenish = true) => {
+  const result = await window.mainApi?.invoke('apiBgCache-getRandom')
+  if (result) {
+    tempSrc.value = `url(${result})`
+  } else {
+    const fallback = await window.mainApi?.invoke('apiBgCache-getOne')
+    if (fallback) {
+      tempSrc.value = `url(${fallback})`
+    }
+  }
+  if (replenish) {
+    const maxCache = (activeBG.value as any).maxCache || 5
+    window.mainApi?.invoke('apiBgCache-fill', maxCache)
+  }
+}
+
 const startApiRefreshTimer = () => {
   stopApiRefreshTimer()
   if (activeBG.value.type !== 'api' || activeBG.value.switchMode !== 'time') return
   const time = (activeBG.value.timer || 5) * 60 * 1000
   apiRefreshTimer = setInterval(() => {
-    tempSrc.value = `url(${activeBG.value.src}${activeBG.value.src.includes('?') ? '&' : '?'}t=${Date.now()})`
+    loadApiBgFromCache()
   }, time)
 }
 
@@ -230,7 +246,7 @@ watch(
     if (newType[0] === 'random-folder' && newType[1]) {
       loadRandomFolderSource()
     } else if (newType[0] === 'api') {
-      tempSrc.value = `url(${activeBG.value.src}${activeBG.value.src.includes('?') ? '&' : '?'}t=${Date.now()})`
+      loadApiBgFromCache()
       startApiRefreshTimer()
     }
   },
@@ -293,7 +309,7 @@ onMounted(async () => {
   if (activeBG.value.type === 'random-folder') {
     await loadRandomFolderSource()
   } else if (activeBG.value.type === 'api') {
-    tempSrc.value = `url(${activeBG.value.src}${activeBG.value.src.includes('?') ? '&' : '?'}t=${Date.now()})`
+    loadApiBgFromCache()
     startApiRefreshTimer()
   }
   if (playing.value) {

--- a/src/renderer/components/BackgroundPage.vue
+++ b/src/renderer/components/BackgroundPage.vue
@@ -191,18 +191,19 @@ const stopApiRefreshTimer = () => {
 }
 
 const loadApiBgFromCache = async (replenish = true) => {
-  const result = await window.mainApi?.invoke('apiBgCache-getRandom')
+  const apiUrl = activeBG.value.src || undefined
+  const result = await window.mainApi?.invoke('apiBgCache-getRandom', apiUrl)
   if (result) {
     tempSrc.value = `url(${result})`
   } else {
-    const fallback = await window.mainApi?.invoke('apiBgCache-getOne')
+    const fallback = await window.mainApi?.invoke('apiBgCache-getOne', apiUrl)
     if (fallback) {
       tempSrc.value = `url(${fallback})`
     }
   }
   if (replenish) {
     const maxCache = (activeBG.value as any).maxCache || 5
-    window.mainApi?.invoke('apiBgCache-fill', maxCache)
+    window.mainApi?.invoke('apiBgCache-fill', maxCache, apiUrl)
   }
 }
 

--- a/src/renderer/components/BackgroundPage.vue
+++ b/src/renderer/components/BackgroundPage.vue
@@ -192,13 +192,14 @@ const stopApiRefreshTimer = () => {
 
 const loadApiBgFromCache = async (replenish = true) => {
   const apiUrl = activeBG.value.src || undefined
-  const result = await window.mainApi?.invoke('apiBgCache-getRandom', apiUrl)
-  if (result) {
-    tempSrc.value = `url(${result})`
+  // 优先下载新的，网络失败时从缓存随机取
+  const fresh = await window.mainApi?.invoke('apiBgCache-getOne', apiUrl)
+  if (fresh) {
+    tempSrc.value = `url(${fresh})`
   } else {
-    const fallback = await window.mainApi?.invoke('apiBgCache-getOne', apiUrl)
-    if (fallback) {
-      tempSrc.value = `url(${fallback})`
+    const cached = await window.mainApi?.invoke('apiBgCache-getRandom', apiUrl)
+    if (cached) {
+      tempSrc.value = `url(${cached})`
     }
   }
   if (replenish) {

--- a/src/renderer/components/BackgroundPage.vue
+++ b/src/renderer/components/BackgroundPage.vue
@@ -176,8 +176,9 @@ watch(
 watch(
   () => currentTrack.value?.id,
   () => {
-    stopApiRefreshTimer()
-    if (activeBG.value.type === 'api' && activeBG.value.switchMode === 'track') {
+    if (activeBG.value.type !== 'api') return
+    if (activeBG.value.switchMode === 'track') {
+      stopApiRefreshTimer()
       loadApiBgFromCache()
     }
   }

--- a/src/renderer/components/ButtonIcon.vue
+++ b/src/renderer/components/ButtonIcon.vue
@@ -42,7 +42,7 @@ button {
   :deep(.svg-icon) {
     height: 16px;
     width: 16px;
-    color: var(--color-text);
+    color: inherit;
     transition: color 0.3s;
   }
   &:first-child {

--- a/src/renderer/components/CreativePlayer.vue
+++ b/src/renderer/components/CreativePlayer.vue
@@ -253,6 +253,10 @@ const gap = computed(() => {
   return `${sense.lyric.gap}px`
 })
 
+const playedColor = computed(() => {
+  return activeTheme.value.theme.senses.Classic.lyric.playedColor || 'var(--color-wbw-text-played)'
+})
+
 const titleStyle = computed(() => {
   if (activeTheme.value.theme.activeLayout === 'Creative') {
     const sense = senses.value[activeTheme.value.theme.activeLayout]
@@ -952,6 +956,7 @@ $mid: math.ceil(math.div($count, 2));
 
   :deep(.lyric-item) {
     font-size: v-bind(fontSize);
+    color: v-bind(playedColor);
     user-select: none;
     will-change: transform;
   }

--- a/src/renderer/components/LyricPage.vue
+++ b/src/renderer/components/LyricPage.vue
@@ -78,10 +78,10 @@ const stateStore = useNormalStateStore()
 const { showToast } = stateStore
 
 const playerThemeStore = usePlayerThemeStore()
-const { themes } = storeToRefs(playerThemeStore)
+const { activeTheme } = storeToRefs(playerThemeStore)
 
 const sense = computed(() => {
-  const theme = themes.value.Classic[0].theme
+  const theme = activeTheme.value.theme
   const result = theme.senses.Classic
   return result
 })
@@ -91,6 +91,7 @@ const isNWordByWord = computed(() => sense.value.lyric.wbw)
 const nTranslationMode = computed(() => sense.value.lyric.translation)
 const useMask = computed(() => sense.value.lyric.mask)
 const isZoom = computed(() => sense.value.lyric.zoom)
+const playedColor = computed(() => sense.value.lyric.playedColor || 'var(--color-wbw-text-played)')
 
 const lineMode = computed(() => {
   return !isNWordByWord.value || lyrics.value.every((line) => !line.lyric?.info)
@@ -376,7 +377,7 @@ onBeforeUnmount(() => {
         font-size: v-bind('`${nFontSize}px`');
         background: linear-gradient(
           to right,
-          var(--color-wbw-text-played) 50%,
+          v-bind(playedColor) 50%,
           v-bind('`${unplayColor}`') 50%
         );
         background-clip: text;
@@ -431,7 +432,7 @@ onBeforeUnmount(() => {
   :deep(.lyric.active) {
     .lyric-line span,
     .translation span {
-      color: var(--color-wbw-text-played);
+      color: v-bind(playedColor);
     }
   }
   :deep(.lyric) {

--- a/src/renderer/components/ModalBackground.vue
+++ b/src/renderer/components/ModalBackground.vue
@@ -65,6 +65,21 @@
               />
             </div>
           </div>
+          <div class="item">
+            <div class="left">
+              <div class="title">API 缓存数量</div>
+            </div>
+            <div class="right">
+              <input
+                :value="apiMaxCache"
+                class="cache-input"
+                type="number"
+                :min="1"
+                :max="20"
+                @input="onApiMaxCacheChange"
+              />
+            </div>
+          </div>
         </template>
         <div v-if="activeBG.type === 'custom-video'" class="item">
           <div class="left">
@@ -262,6 +277,21 @@ const selectSource = async () => {
   }
 }
 
+const apiMaxCache = computed({
+  get: () => (activeBG.value as any).maxCache ?? 5,
+  set: (val: number) => {
+    ;(activeBG.value as any).maxCache = val
+    window.mainApi?.invoke('apiBgCache-setCount', val)
+  }
+})
+
+const onApiMaxCacheChange = (e: Event) => {
+  const val = parseInt((e.target as HTMLInputElement).value)
+  if (!isNaN(val) && val >= 1 && val <= 20) {
+    apiMaxCache.value = val
+  }
+}
+
 const reset = () => {
   if (!isCustomize.value) return
   activeBG.value.src = activeBG.value.type === 'lottie' ? 'snow' : ''
@@ -448,5 +478,17 @@ const close = () => {
 }
 .toggle input:checked + label:after {
   left: 26px;
+}
+
+.cache-input {
+  width: 60px;
+  height: 32px;
+  background: var(--color-secondary-bg-for-transparent);
+  border: none;
+  border-radius: 8px;
+  color: var(--color-text);
+  font-size: 16px;
+  font-weight: 600;
+  text-align: center;
 }
 </style>

--- a/src/renderer/components/ModalBackground.vue
+++ b/src/renderer/components/ModalBackground.vue
@@ -80,6 +80,14 @@
               />
             </div>
           </div>
+          <div class="item">
+            <div class="left">
+              <div class="title">保存当前背景</div>
+            </div>
+            <div class="right">
+              <button class="btn save-bg-btn" @click="saveCurrentBg">保存</button>
+            </div>
+          </div>
         </template>
         <div v-if="activeBG.type === 'custom-video'" class="item">
           <div class="left">
@@ -172,6 +180,7 @@ import VueSlider from './VueSlider.vue'
 import { useNormalStateStore } from '../store/state'
 import { usePlayerThemeStore, createBG } from '../store/playerTheme'
 import { useI18n } from 'vue-i18n'
+import { currentApiBgPath } from '../store/currentBg'
 
 const stateStore = useNormalStateStore()
 const { backgroundModal } = storeToRefs(stateStore)
@@ -290,6 +299,11 @@ const onApiMaxCacheChange = (e: Event) => {
   if (!isNaN(val) && val >= 1 && val <= 20) {
     apiMaxCache.value = val
   }
+}
+
+const saveCurrentBg = async () => {
+  if (!currentApiBgPath.value) return
+  await window.mainApi?.invoke('save-api-bg', currentApiBgPath.value)
 }
 
 const reset = () => {

--- a/src/renderer/components/ModalPlayerFont.vue
+++ b/src/renderer/components/ModalPlayerFont.vue
@@ -108,6 +108,18 @@
           </div>
           <div class="item">
             <div class="left">
+              <div class="title">按钮颜色</div>
+            </div>
+            <div class="right">
+              <VuePickColors
+                v-model:value="playerBtnColorValue"
+                :theme="activeTheme.theme.activeBG === 'gradient' ? 'dark' : 'light'"
+                format="rgb"
+              />
+            </div>
+          </div>
+          <div class="item">
+            <div class="left">
               <div class="title">
                 {{ $t('settings.osdLyric.textAlign.text') }}
               </div>
@@ -300,6 +312,13 @@ const playedColor = computed({
     activeTheme.value.theme.senses.Classic.lyric.playedColor || 'var(--color-wbw-text-played)',
   set: (value: string) => {
     activeTheme.value.theme.senses.Classic.lyric.playedColor = value
+  }
+})
+
+const playerBtnColorValue = computed({
+  get: () => activeTheme.value.theme.playerBtnColor || 'var(--color-text)',
+  set: (value: string) => {
+    activeTheme.value.theme.playerBtnColor = value
   }
 })
 

--- a/src/renderer/components/ModalPlayerFont.vue
+++ b/src/renderer/components/ModalPlayerFont.vue
@@ -96,6 +96,18 @@
           </div>
           <div class="item">
             <div class="left">
+              <div class="title">歌词高亮颜色</div>
+            </div>
+            <div class="right">
+              <VuePickColors
+                v-model:value="playedColor"
+                :theme="activeTheme.theme.activeBG === 'gradient' ? 'dark' : 'light'"
+                format="rgb"
+              />
+            </div>
+          </div>
+          <div class="item">
+            <div class="left">
               <div class="title">
                 {{ $t('settings.osdLyric.textAlign.text') }}
               </div>
@@ -193,6 +205,7 @@ import { storeToRefs } from 'pinia'
 import { useNormalStateStore } from '../store/state'
 import { usePlayerThemeStore } from '../store/playerTheme'
 import VueSlider from 'vue-3-slider-component'
+import VuePickColors from 'vue-pick-colors'
 import CustomSelect from './CustomSelect.vue'
 import { useI18n } from 'vue-i18n'
 
@@ -279,6 +292,14 @@ const fontSize = computed({
   get: () => currentTheme.value.lyric.fontSize,
   set: (value: number) => {
     currentTheme.value.lyric.fontSize = value
+  }
+})
+
+const playedColor = computed({
+  get: () =>
+    activeTheme.value.theme.senses.Classic.lyric.playedColor || 'var(--color-wbw-text-played)',
+  set: (value: string) => {
+    activeTheme.value.theme.senses.Classic.lyric.playedColor = value
   }
 })
 

--- a/src/renderer/components/PlayerBar.vue
+++ b/src/renderer/components/PlayerBar.vue
@@ -337,7 +337,7 @@ watch(showLyrics, (value) => {
   background-color: var(--color-navbar-bg);
   z-index: 20;
 
-  .svg-icon {
+  :deep(.svg-icon) {
     color: var(--player-btn-color);
   }
 }

--- a/src/renderer/components/PlayerBar.vue
+++ b/src/renderer/components/PlayerBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="player">
+  <div class="player" :style="{ '--player-btn-color': playerBtnColor }">
     <div class="progress-bar">
       <vue-slider
         ref="playerBarRef"
@@ -163,6 +163,7 @@ import { useNormalStateStore } from '../store/state'
 import { hasListSource, getListSourcePath } from '../utils/playlist'
 import { useStreamMusicStore } from '../store/streamingMusic'
 import { useSettingsStore } from '../store/settings'
+import { usePlayerThemeStore } from '../store/playerTheme'
 import ButtonIcon from './ButtonIcon.vue'
 import SvgIcon from './SvgIcon.vue'
 import { computed, ref, watch } from 'vue'
@@ -204,6 +205,9 @@ const { showLyrics, enableScrolling } = storeToRefs(stateStore)
 
 const dataStore = useDataStore()
 const { likeATrack } = dataStore
+
+const playerThemeStore = usePlayerThemeStore()
+const playerBtnColor = computed(() => playerThemeStore.activeTheme.theme.playerBtnColor)
 
 const streamMusicStore = useStreamMusicStore()
 const { likeAStreamTrack } = streamMusicStore
@@ -332,6 +336,10 @@ watch(showLyrics, (value) => {
   backdrop-filter: saturate(180%) blur(30px);
   background-color: var(--color-navbar-bg);
   z-index: 20;
+
+  .svg-icon {
+    color: var(--player-btn-color);
+  }
 }
 :deep(.progress-bar) {
   margin-top: -6px !important;

--- a/src/renderer/store/currentBg.ts
+++ b/src/renderer/store/currentBg.ts
@@ -1,0 +1,3 @@
+import { ref } from 'vue'
+
+export const currentApiBgPath = ref<string | null>(null)

--- a/src/renderer/store/playerTheme.ts
+++ b/src/renderer/store/playerTheme.ts
@@ -84,7 +84,8 @@ export const createBG = () => {
       color: 'auto',
       useExtractedColor: false,
       switchMode: 'track',
-      timer: 5
+      timer: 5,
+      maxCache: 5
     }
   ]
 
@@ -122,6 +123,7 @@ const createTheme = (name: 'default' | 'snow' | 'letter') => {
           font: 'system-ui',
           fontSize: 28,
           fontBold: false,
+          playedColor: 'var(--color-wbw-text-played)',
           gap: 0,
           mask: true,
           wbw: true,
@@ -136,6 +138,7 @@ const createTheme = (name: 'default' | 'snow' | 'letter') => {
           fontSize: 4.5,
           gap: 6,
           fontBold: false,
+          playedColor: 'var(--color-wbw-text-played)',
           align: {
             left: 'hingeFlyIn',
             center: 'splitAndMerge',
@@ -157,6 +160,7 @@ const createTheme = (name: 'default' | 'snow' | 'letter') => {
           font: 'system-ui',
           fontSize: 4.5,
           fontBold: false,
+          playedColor: 'var(--color-wbw-text-played)',
           gap: 6,
           align: {
             center: 'splitAndMerge'

--- a/src/renderer/store/playerTheme.ts
+++ b/src/renderer/store/playerTheme.ts
@@ -115,6 +115,7 @@ const createTheme = (name: 'default' | 'snow' | 'letter') => {
   const theme: Theme = {
     activeLayout: option.layout,
     activeBG: option.bgType,
+    playerBtnColor: 'var(--color-text)',
     senses: {
       Classic: {
         cover: 0,

--- a/src/renderer/views/PlayPage.vue
+++ b/src/renderer/views/PlayPage.vue
@@ -4,6 +4,7 @@
       <div
         v-if="showLyrics"
         class="player-container"
+        :style="{ '--player-btn-color': playerBtnColor }"
         @mouseenter="hover = true"
         @mouseleave="hover = false"
       >
@@ -122,6 +123,8 @@ const playerThemeStore = usePlayerThemeStore()
 const { activeTheme, activeBG } = storeToRefs(playerThemeStore)
 const { resetTheme } = playerThemeStore
 
+const playerBtnColor = computed(() => activeTheme.value.theme.playerBtnColor || 'var(--color-text)')
+
 const showSenseSelector = ref(false)
 const tabIdx = ref(0)
 const titleIdx = ref(0)
@@ -197,6 +200,10 @@ watch(
   height: 100%;
   z-index: 20;
   background-color: var(--bg-color);
+
+  :deep(.button-icon .svg-icon) {
+    color: var(--player-btn-color);
+  }
 }
 
 .buttons-icons {

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -74,6 +74,7 @@ type BgSource =
       useExtractedColor: boolean
       switchMode: 'track' | 'time'
       timer: number
+      maxCache: number
     }
 
 export type Theme = {
@@ -90,6 +91,7 @@ export type Theme = {
         font: string
         fontSize: number
         fontBold: boolean
+        playedColor?: string
         gap: number
         mask: boolean
         wbw: boolean
@@ -110,6 +112,7 @@ export type Theme = {
         fontSize: number
         gap: number
         fontBold: boolean
+        playedColor?: string
         align: {
           left: AniName
           center: AniName
@@ -128,6 +131,7 @@ export type Theme = {
         font: string
         fontSize: number
         fontBold: boolean
+        playedColor?: string
         gap: number
         align: {
           center: AniName

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -80,6 +80,7 @@ type BgSource =
 export type Theme = {
   activeLayout: LayoutMode
   activeBG: BgType
+  playerBtnColor?: string
   senses: {
     Classic: {
       /**

--- a/tests/lyric-color-active-theme-check.cjs
+++ b/tests/lyric-color-active-theme-check.cjs
@@ -1,0 +1,29 @@
+const fs = require('fs')
+
+const lyric = fs.readFileSync('src/renderer/components/LyricPage.vue', 'utf8')
+const modal = fs.readFileSync('src/renderer/components/ModalPlayerFont.vue', 'utf8')
+const creative = fs.readFileSync('src/renderer/components/CreativePlayer.vue', 'utf8')
+
+if (!lyric.includes('const { activeTheme } = storeToRefs(playerThemeStore)')) {
+  throw new Error('LyricPage must read activeTheme from playerThemeStore')
+}
+
+if (!lyric.includes('activeTheme.value.theme') || !lyric.includes('theme.senses.Classic')) {
+  throw new Error('LyricPage must use the active theme Classic lyric settings')
+}
+
+if (lyric.includes('themes.value.Classic[0].theme')) {
+  throw new Error('LyricPage still reads the built-in Classic theme instead of active theme')
+}
+
+if (!modal.includes('activeTheme.value.theme.senses.Classic.lyric.playedColor = value')) {
+  throw new Error('ModalPlayerFont must save playedColor to the main lyric settings')
+}
+
+if (!creative.includes('const playedColor = computed(() =>')) {
+  throw new Error('CreativePlayer must read playedColor for picked lyrics')
+}
+
+if (!creative.includes('color: v-bind(playedColor);')) {
+  throw new Error('CreativePlayer picked lyrics must use playedColor')
+}


### PR DESCRIPTION
## 变更内容

### 1. 歌词高亮颜色自定义
- 新增 `playedColor` 字段到主题歌词配置（Classic/Creative/Letter 三种布局）
- ModalPlayerFont.vue 添加颜色选择器（VuePickColors）
- LyricPage.vue 和 CreativePlayer.vue 使用 `v-bind(playedColor)` 渲染高亮色
- 默认值 `var(--color-wbw-text-played)`，向后兼容

### 2. API 背景图片本地缓存
- 新增 `src/main/apiBgCache.ts`：基于本地文件的 LRU 缓存模块
- 缓存目录 `userData/apiBgCache/`，索引文件 `index.json`
- 4 个 IPC 通道：getRandom / getOne / fill / setCount
- BackgroundPage.vue 改为优先从缓存加载，网络故障时仍可用
- ModalBackground.vue 新增缓存数量设置（1-20 张，默认 5）

## 审查说明
- `apiBgCache.fillTo()` 顺序下载，避免索引文件竞争写入
- `playedColor` 回退到 CSS 变量 `var(--color-wbw-text-played)`，旧版主题不报错
- LyricPage.vue 的 `sense` 改为读取 `activeTheme`（之前硬编码 Classic[0]）